### PR TITLE
Add Raspberry Pi setup docs and requirements-pi.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,36 @@ Backward-compatible capture flags:
 python sentinel.py --capture-face Darren --capture-count 25 --capture-out ./faces
 ```
 
-## Hardware setup (Raspberry Pi)
-Install hardware-specific packages on the Pi (often via apt/pip):
-- `picamera2`
-- `rpi_ws281x`
-- `adafruit-circuitpython-servokit`
+## Raspberry Pi setup
+### System packages (apt)
+```bash
+sudo apt update
+sudo apt install -y python3-picamera2 libcamera-apps i2c-tools
+```
+
+### Enable I2C
+```bash
+sudo raspi-config
+```
+Navigate to **Interface Options** → **I2C** and enable it, then reboot if prompted.
+
+### Python dependencies (pip)
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install -r requirements-pi.txt
+```
+
+### Hardware run command
+```bash
+sudo -E .venv/bin/python sentinel.py
+```
+
+### Hardware assumptions
+- WS2812 data on GPIO18 (Pin 12)
+- PCA9685 at I2C address `0x40`
+- Camera uses picamera2/libcamera
 
 These are imported only in hardware mode, so simulation can run on any machine.
 

--- a/requirements-pi.txt
+++ b/requirements-pi.txt
@@ -1,0 +1,2 @@
+rpi-ws281x
+adafruit-circuitpython-servokit


### PR DESCRIPTION
### Motivation
- Provide clear Raspberry Pi installation steps and isolate Pi-only Python packages so the main `requirements.txt` remains cross-platform.

### Description
- Add `requirements-pi.txt` containing `rpi-ws281x` and `adafruit-circuitpython-servokit`.
- Replace the previous hardware note in `README.md` with a `Raspberry Pi setup` section that documents apt installs (`python3-picamera2`, `libcamera-apps`, `i2c-tools`), enabling I2C via `raspi-config`, pip installation steps (`pip install -r requirements.txt` and `pip install -r requirements-pi.txt`), the hardware run command `sudo -E .venv/bin/python sentinel.py`, and hardware assumptions (WS2812 data on GPIO18 / Pin 12, PCA9685 at I2C address `0x40`, and camera via picamera2/libcamera).

### Testing
- No automated tests were run because the changes are documentation and dependency-list only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698942a57a3483259ac1a1f263b9debe)