### PR TITLE
Auto-train LBPH model after face capture (add `--no-train`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python sentinel.py --simulate --duration 60
 
 ### Face recognition (requires trained model)
 ```bash
-python sentinel.py --enable-face --model ./face_model.yml --labels ./face_labels.json
+python sentinel.py --enable-face --model ./models/lbph.yml --labels ./models/labels.json
 ```
 
 ### Dataset structure
@@ -42,20 +42,25 @@ Store face images under `faces/<name>/<image>.jpg` (one folder per person). The 
 ```bash
 # 1) Capture faces (Pi camera) into faces/<name>/<image>.jpg
 python sentinel.py capture-face --name Darren --count 25 --out ./faces
+# (Optional) Skip auto-training:
+# python sentinel.py capture-face --name Darren --count 25 --out ./faces --no-train
 
 # 2) (Optional) scan for bad images and auto-move them into faces/_bad/...
 python sentinel.py scan-faces --dataset ./faces --move-bad
 
-# 3) Train LBPH model + labels from faces/<name>/*.jpg
-python sentinel.py train-lbph --dataset ./faces --model-out ./face_model.yml --labels-out ./face_labels.json
+# 3) Auto-training runs immediately after capture (writes ./models/lbph.yml + ./models/labels.json).
+#    You can also train manually:
+python sentinel.py train-lbph --dataset ./faces --model-out ./models/lbph.yml --labels-out ./models/labels.json
 
 # 4) Run recognition using the trained model
-python sentinel.py --enable-face --model ./face_model.yml --labels ./face_labels.json
+python sentinel.py --enable-face --model ./models/lbph.yml --labels ./models/labels.json
 ```
 
 Backward-compatible capture flags:
 ```bash
 python sentinel.py --capture-face Darren --capture-count 25 --capture-out ./faces
+# (Optional) skip auto-training:
+# python sentinel.py --capture-face Darren --capture-count 25 --capture-out ./faces --no-train
 ```
 
 ## Raspberry Pi setup


### PR DESCRIPTION
### Motivation
- Automatically train/update the LBPH face model immediately after a successful face capture to make recognition usable right away.
- Provide an opt-out for debugging runs via a `--no-train` flag and avoid touching hardware behavior.
- Improve UX by documenting the new flow and providing helpful errors when OpenCV face module is missing.

### Description
- Added `auto_train_lbph(dataset_dir: Path, name: str, *, model_out: Path, labels_out: Path)` to `sentinel.py` which verifies `faces/<name>/` contains images, invokes `train_lbph`, and prints the saved model/labels paths and next steps.
- Invoke `auto_train_lbph` automatically after `capture-face` completes (both subcommand and backwards-compatible `--capture-face` flag), unless the new `--no-train` option is provided.
- Updated CLI defaults for model/labels to `./models/lbph.yml` and `./models/labels.json` and added `--no-train` to the `capture-face` parser.
- Improved error handling: `auto_train_lbph` catches missing OpenCV face module or training `RuntimeError` and prints a clear message with a tip to install `opencv-contrib-python`.
- Updated `README.md` to document the `capture-face` command, auto-training behavior, the `--no-train` option, and how to run recognition using the generated `./models` files.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69894f57b2b88325bc9e72049fcfddd9)