### PR TITLE
Add YAML configuration loading and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Mobile robot project with motion tracking, LED "eye," servo scanning, and option
 ## Requirements
 - Python 3.9+ recommended
 - Optional Raspberry Pi hardware libraries (see Hardware setup)
+- Configuration uses YAML via PyYAML (included in `requirements.txt`).
 
 ## Setup
 ```bash
@@ -23,6 +24,31 @@ pip install -r requirements.txt
 ```bash
 python sentinel.py
 ```
+
+## Configuration
+Sentinel reads `config.yaml` from the same directory as `sentinel.py`. If the file is missing, the defaults below are used.
+
+```bash
+cp config.example.yaml config.yaml
+```
+
+CLI flags always override config values when provided (e.g., `--model`, `--labels`, `--capture-count`).
+
+Config fields:
+- **Paths**
+  - `faces_dir` (default `faces`)
+  - `models_dir` (default `models`)
+  - `model_path` (default `models/lbph.yml`)
+  - `labels_path` (default `models/labels.json`)
+- **Hardware**
+  - `led_count`
+  - `led_pin` (default GPIO18)
+  - `led_brightness` (0-255)
+  - `pca9685_i2c_address` (default `0x40`)
+  - `servo_channel`
+  - `servo_left` / `servo_center` / `servo_right`
+- **Capture defaults**
+  - `capture_count_default` (default `25`)
 
 ## Usage
 ### Simulation (no Pi hardware)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,32 @@
+# Copy this file to config.yaml (in the same directory as sentinel.py)
+# and tweak values as needed.
+
+paths:
+  # Directory for captured face datasets.
+  faces_dir: "faces"
+  # Directory for model/label artifacts.
+  models_dir: "models"
+  # LBPH model file path.
+  model_path: "models/lbph.yml"
+  # Labels JSON path.
+  labels_path: "models/labels.json"
+
+hardware:
+  # Number of LEDs in the ring.
+  led_count: 8
+  # GPIO pin for WS2812 data (GPIO18).
+  led_pin: 18
+  # LED brightness (0-255).
+  led_brightness: 35
+  # PCA9685 I2C address.
+  pca9685_i2c_address: 0x40
+  # Servo channel on the PCA9685.
+  servo_channel: 0
+  # Servo angles (degrees).
+  servo_left: 130
+  servo_center: 90
+  servo_right: 50
+
+capture:
+  # Default number of images to capture.
+  capture_count_default: 25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Base dependencies used by dataset utilities and face recognition
 numpy>=1.24.0
 opencv-contrib-python>=4.8.0
+PyYAML>=6.0
 
 # Raspberry Pi hardware dependencies (install on-device, typically via apt/pip):
 # picamera2


### PR DESCRIPTION
### Motivation
- Centralize paths, pins, and defaults into a single settings object loaded once at startup so configuration is easier to manage without changing runtime behavior. 
- Make YAML the preferred config format (optional), document usage, and provide an example to simplify on-device customization.

### Description
- Add a `Settings` dataclass and YAML loader (`_load_yaml_config` + `load_settings`) that reads `config.yaml` and returns a `Settings` instance; the settings are loaded once in `dispatch_cli` and stored in the global `CFG`. 
- Preserve defaults when `config.yaml` is missing and keep CLI behavior intact by passing `CFG` into `build_arg_parser`; CLI flags continue to override values provided by the config, and the program prints a one-line startup message indicating whether the config was loaded (and its path). 
- Add `config.example.yaml` with commented fields and update `README.md` to document config location, how to copy the example to `config.yaml`, and how CLI flags override config values. 
- Add `PyYAML` to `requirements.txt` and make small, local naming/usage updates (e.g., `servo_center` replacing `servo_neutral`, `pca9685_i2c_address`, `servo_channel`) while keeping hardware timing and behavior unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698954b955548325926ea808fc59a78d)