### PR TITLE
Add continuous run mode, graceful shutdown, and resilient face fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ pip install -r requirements.txt
 
 ## Run
 ```bash
-python sentinel.py
+python sentinel.py --run continuous
 ```
+
+`--run continuous` is the default runtime mode and keeps Sentinel in the idle/observe/recognize loop until stopped.
+Press `Ctrl+C` for a graceful shutdown (LEDs off, servo centered, camera closed).
 
 ## Configuration
 Sentinel reads `config.yaml` from the same directory as `sentinel.py`. If the file is missing, the defaults below are used.
@@ -60,6 +63,8 @@ python sentinel.py --simulate --duration 60
 ```bash
 python sentinel.py --enable-face --model ./models/lbph.yml --labels ./models/labels.json
 ```
+
+If model files are missing/unreadable, Sentinel now continues running and treats recognitions as `Unknown` instead of crashing.
 
 ### Dataset structure
 Store face images under `faces/<name>/<image>.jpg` (one folder per person). The capture tool writes this structure automatically.


### PR DESCRIPTION
### Motivation
- Keep the main runtime active as a continuous idle/observe/recognize loop and make it easy to run until explicitly stopped. 
- Ensure a graceful shutdown path so hardware and tasks are cleaned up when interrupted (Ctrl+C / SIGTERM). 
- Avoid crashes when face model files or OpenCV face runtime are missing by treating recognition as `Unknown` instead of failing.

### Description
- Add a `--run` CLI flag (currently `continuous` default) and plumb it into `run_sentinel` as `run_mode`, with a validation check for unsupported modes. 
- Implement a simple `UnknownFaceAuth` fallback and wrap `FaceAuth` construction in a `try/except` to fall back on missing model/OpenCV errors. 
- Introduce a `stop_event` and install `SIGINT`/`SIGTERM` handlers (when supported) to await a graceful shutdown in continuous mode, then cancel tasks and run existing cleanup (LED clear, servo center/close, sensor close). 
- Update `README.md` to document `--run continuous`, Ctrl+C behavior, and the new resilient behavior when model files are missing.

### Testing
- Compiled the code with `python -m py_compile sentinel.py src/face.py`, which succeeded. 
- Ran `python sentinel.py --simulate --duration 0.5 --run continuous --log-level INFO` to exercise simulation startup, which succeeded. 
- Launched the process and sent `SIGINT` (via a subprocess script) to verify graceful shutdown and cleanup, which succeeded. 
- Invoked `run_sentinel` with a fake `build_system` and non-existent model/labels to confirm the `FaceAuth` fallback to `UnknownFaceAuth` on `ImportError`/missing files, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ac8aaec2083258fab53ebec0ca114)