### PR TITLE
Add async ramped pan/tilt servo movement and `servo-test` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,23 @@ Config fields:
   - `servo_left` / `servo_center` / `servo_right`
 - **Capture defaults**
   - `capture_count_default` (default `25`)
+- **Servo ramping**
+  - `ramp_step_deg` (default `2`)
+  - `ramp_step_ms` (default `20`)
 
 ## Usage
 ### Simulation (no Pi hardware)
 ```bash
 python sentinel.py --simulate --duration 60
 ```
+
+
+### Servo ramp test
+```bash
+python sentinel.py servo-test pan left
+python sentinel.py servo-test tilt up
+```
+These commands use ramped movement (small angle steps + async delays) instead of instant jumps.
 
 ### Face recognition (requires trained model)
 ```bash

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,3 +30,9 @@ hardware:
 capture:
   # Default number of images to capture.
   capture_count_default: 25
+
+servo:
+  # Ramping increment in degrees per step.
+  ramp_step_deg: 2
+  # Delay between ramp steps in milliseconds.
+  ramp_step_ms: 20


### PR DESCRIPTION
### Motivation
- Reduce current spikes and mechanical shock by moving pan/tilt servos in small timed increments instead of instant jumps.
- Provide an easy way to exercise and validate ramped motion from the CLI without changing existing run-mode or camera/face logic.

### Description
- Added optional `servo` config keys `ramp_step_deg` and `ramp_step_ms` with defaults and updated `load_settings` to read the new `servo:` section while keeping prior behavior when missing.
- Extended the `ServoDriver` protocol with an async `move_to(pan_target, tilt_target)` method and implemented it for both `Pca9685Servo` and `SimServo` so drivers track current pan/tilt angles and initialize both axes to center at startup.
- Implemented non-blocking ramped movement in `Pca9685Servo.move_to` by stepping toward targets by `ramp_step_deg` and awaiting `ramp_step_ms` between steps, and added a no-op async `move_to` in `SimServo` for simulation.
- Added `build_servo(simulate: bool)` helper and a focused `servo-test` CLI subcommand that calls `await servo.move_to(...)` for `pan`/`tilt` + direction tests, and updated `config.example.yaml` and `README.md` to document the new options and test commands.

### Testing
- Ran `python -m py_compile sentinel.py` to validate syntax; it succeeded.
- Executed `python sentinel.py --simulate servo-test pan left` and `python sentinel.py --simulate servo-test tilt up` in simulation mode; both commands completed successfully.
- Ran a short integration-style simulation `python sentinel.py --simulate --run continuous --duration 5` to confirm the program runs with the new servo code; it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a67f5c6883259ba519ee182ee6a0)